### PR TITLE
Issue 10

### DIFF
--- a/drp_python/model_layer/subnet_config_model.py
+++ b/drp_python/model_layer/subnet_config_model.py
@@ -30,4 +30,10 @@ class SubnetConfigModel(BaseModel):
         self.range = subnet_object.get('range')
         self.router = subnet_object.get('router')
         self.type = subnet_object.get('type')
+        self.unmanaged = subnet_object.get('unmanaged')
+        self.pickers = subnet_object.get('pickers')
         self.extension = subnet_object.get('extension', {})
+        if self.unmanaged is None:
+            self.unmanaged = False
+        if self.pickers is None:
+            self.pickers = ['hint', 'nextFree', 'mostExpired']

--- a/drp_python/model_layer/subnet_model.py
+++ b/drp_python/model_layer/subnet_model.py
@@ -41,4 +41,3 @@ class SubnetModel(BaseModel):
         self.pickers = subnet_object.get('pickers')
         self.strategy = subnet_object.get('strategy')
         self.unmanaged = subnet_object.get('unmanaged')
-

--- a/drp_python/model_layer/subnet_model.py
+++ b/drp_python/model_layer/subnet_model.py
@@ -40,3 +40,5 @@ class SubnetModel(BaseModel):
         self.options = subnet_object.get('options')
         self.pickers = subnet_object.get('pickers')
         self.strategy = subnet_object.get('strategy')
+        self.unmanaged = subnet_object.get('unmanaged')
+

--- a/drp_python/translation_layer/subnets_translation.py
+++ b/drp_python/translation_layer/subnets_translation.py
@@ -74,13 +74,15 @@ def convert_to_drp(subnet_model):
         "Name": subnet_model.name,
         "OnlyReservations": True,
         "Pickers": [
-            "hint"
+            "hint",
+            "nextFree",
+            "mostExpired"
         ],
         "Strategy": "MAC",
         "Proxy": False,
         "ReservedLeaseTime": subnet_model.default_lease,
         "Subnet": address,
-        "Unmanaged": True,
+        "Unmanaged": False,
         "Options": [
             {
                 "Code": 6,

--- a/drp_python/translation_layer/subnets_translation.py
+++ b/drp_python/translation_layer/subnets_translation.py
@@ -73,11 +73,7 @@ def convert_to_drp(subnet_model):
         "Enabled": True,
         "Name": subnet_model.name,
         "OnlyReservations": True,
-        "Pickers": [
-            "hint",
-            "nextFree",
-            "mostExpired"
-        ],
+        "Pickers": subnet_model.pickers,
         "Strategy": "MAC",
         "Proxy": False,
         "ReservedLeaseTime": subnet_model.default_lease,

--- a/tests/functional/create_machines_test.py
+++ b/tests/functional/create_machines_test.py
@@ -45,7 +45,7 @@ machine_object = {
 class MachineTest(unittest.TestCase):
 
     def setUp(self):
-        self.session = HttpSession('https://10.197.113.130:8092',
+        self.session = HttpSession('https://10.197.113.126:8092',
                                    login['username'],
                                    login['password'])
 

--- a/tests/functional/create_subnets_test.py
+++ b/tests/functional/create_subnets_test.py
@@ -51,7 +51,7 @@ subnet_object = {
 class SubnetTest(unittest.TestCase):
 
     def setUp(self):
-        self.session = HttpSession('https://10.197.113.130:8092',
+        self.session = HttpSession('https://10.197.113.126:8092',
                                    login['username'],
                                    login['password'])
 

--- a/tests/unit/subnet_translation_test.py
+++ b/tests/unit/subnet_translation_test.py
@@ -103,7 +103,7 @@ class SubnetTranslationTest(unittest.TestCase):
                                           'Value': '10.197.111.1'},
                                          {'Code': 28,
                                           'Value': '10.197.111.255'}])
-        self.assertEqual(model.pickers, ['hint'])
+        self.assertEqual(model.pickers, ['hint', 'nextFree', 'mostExpired'])
         self.assertEqual(model.strategy, 'MAC')
 
         model = self.subnet_translation.get_subnet(
@@ -136,7 +136,7 @@ class SubnetTranslationTest(unittest.TestCase):
                                           'Value': '10.197.111.1'},
                                          {'Code': 28,
                                           'Value': '10.197.111.255'}])
-        self.assertEqual(model.pickers, ['hint'])
+        self.assertEqual(model.pickers, ['hint', 'nextFree', 'mostExpired'])
         self.assertEqual(model.strategy, 'MAC')
 
     def test_update_subnet(self):
@@ -171,7 +171,7 @@ class SubnetTranslationTest(unittest.TestCase):
             {'Code': 3, 'Value': '10.197.111.2'},
             {'Code': 28,
              'Value': '10.197.111.255'}])
-        self.assertEqual(model.pickers, ['hint'])
+        self.assertEqual(model.pickers, ['hint', 'nextFree', 'mostExpired'])
         self.assertEqual(model.strategy, 'MAC')
 
     def test_delete_subnet(self):


### PR DESCRIPTION
#### What does this PR do?
Defaults Unmanaged and Pickers for subnets. 
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
python setup.py test
#### Any background context you want to provide?
They were being hardcoded to True and ['hint'].  Changed to both allow the client to set and default to 
False and ['hint', 'nextFree', 'mostExpired']
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes #10 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
Yes
- Does this patch update any configuration files?
No
