### PR TITLE
Fix python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 urllib3
 netaddr
+enum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 urllib3
 netaddr
-enum
+enum==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-enum>=0.4.7
-requests>=2.19.1
-urllib3>=1.23
-netaddr>=0.7.19
-
+requests
+urllib3
+netaddr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 urllib3
 netaddr
-enum==0.4.6
+enum34

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-certifi>=2018.8.24
-chardet>=3.0.4
 enum>=0.4.7
-idna>=2.7
 requests>=2.19.1
 urllib3>=1.23
 netaddr>=0.7.19
-http>=0.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,13 @@ version = 0.1.0
 home-page = https://github.com/cablelabs/drp-python
 author = Dan Schrimpsher
 author-email = d.schrimpsher@cablelabs.com
+license='Apache 2.0',
+description='Python Module to Support Digital Rebar API',
+long_description='Python bindings to Digital Rebar API.',
+classifiers=[
+    'Topic :: System :: Installation/Setup'
+   ],
+   keywords='network boot, digital rebar, installation, NFV',
 
 [files]
 packages = drp_python

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,16 +4,6 @@ version = 0.1.0
 home-page = https://github.com/cablelabs/drp-python
 author = Dan Schrimpsher
 author-email = d.schrimpsher@cablelabs.com
-license='Apache 2.0',
-description='Python Module to Support Digital Rebar API',
-long_description='Python bindings to Digital Rebar API.',
-classifiers=[
-    'Topic :: System :: Installation/Setup'
-   ],
-   keywords='network boot, digital rebar, installation, NFV',
 
 [files]
 packages = drp_python
-
-[pycodestyle]
-max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,6 @@ from setuptools import setup
 
 
 setup(
-    license='Apache 2.0',
-    description='Python Module to Support Digital Rebar API',
-    long_description='Python bindings to Digital Rebar API.',
-    classifiers=[
-        'Topic :: System :: Installation/Setup'
-    ],
-    keywords='network boot, digital rebar, installation, NFV',
     setup_requires=['pbr>=2.0.0'],
     test_suite='tests',
     pbr=True,


### PR DESCRIPTION
#### What does this PR do?
Fixes the python dependencies that had problems exposed while working on the AWS CI scripts.
The version numbers were conflicting with the apt package virtinst causing pip to become corrupted. We are installing virtinst on the same host as drb-python as the host VM will be the build server and running the host hypervisor.
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
Run snaps-boot CI scripts but change the requirements-git.txt drb-python line item from the branch 'master' to this one 'aws_ci'
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
none for this repo, but the one in snaps-boot is issue #260
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no
